### PR TITLE
`use v6.c` for whenever outside of react/supply

### DIFF
--- a/lib/HTTP/Server/Ogre.pm6
+++ b/lib/HTTP/Server/Ogre.pm6
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 =begin pod
 

--- a/lib/HTTP/Server/Ogre/Http2Protocol.pm6
+++ b/lib/HTTP/Server/Ogre/Http2Protocol.pm6
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 
 use HTTP::Server::Ogre::HTTP2::FrameParser;
 use HTTP::Server::Ogre::HTTP2::RequestParser;


### PR DESCRIPTION
See issue #3. This makes tests pass for rakudo versions that
have `v6.d` by default.