### PR TITLE
Adapt to rename of Path::Iterator to Path::Finder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ perl6:
 install:
   - rakudobrew build zef
   - zef install Test::META
-  - zef install Path::Iterator
+  - zef install Path::Finder
   - zef install --depsonly --/test .
 script:
   - PERL6LIB=$PWD/lib prove -e perl6 -vr t/

--- a/META6.json
+++ b/META6.json
@@ -31,7 +31,7 @@
     "P6W"
   ],
   "test-depends" : [
-    "Path::Iterator",
+    "Path::Finder",
     "Test::META"
   ],
   "version" : "0.0.4"

--- a/t/00-lint.t
+++ b/t/00-lint.t
@@ -1,15 +1,15 @@
 use v6;
 use lib 'lib';
 use Test;
-use Path::Iterator;
+use Path::Finder;
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 
 if AUTHOR {
     # check for use v6;
     my @dirs = '.';
-    for Path::Iterator.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
-        my @lines = $file.IO.lines;
+    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+        my @lines = $file.lines;
         my $expected_line = 0;
         if @lines[0] eq '#!/usr/bin/env perl6' {
             $expected_line = 1;

--- a/t/00-lint.t
+++ b/t/00-lint.t
@@ -8,7 +8,7 @@ constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 if AUTHOR {
     # check for use v6;
     my @dirs = '.';
-    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+    for find(@dirs, :ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /), :skip-vcs) -> $file {
         my @lines = $file.lines;
         my $expected_line = 0;
         if @lines[0] eq '#!/usr/bin/env perl6' {

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -9,7 +9,7 @@ if AUTHOR {
     # check for trailing spaces
     # check for tabs
     my @dirs = '.';
-    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+    for find(@dirs, :ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /), :skip-vcs) -> $file {
         my @lines = $file.lines;
         my @spaces = @lines.grep(rx/\s$/);
         is-deeply @spaces, [], "spaces at the end of $file";

--- a/t/00-tidy.t
+++ b/t/00-tidy.t
@@ -1,7 +1,7 @@
 use v6;
 use lib 'lib';
 use Test;
-use Path::Iterator;
+use Path::Finder;
 
 constant AUTHOR = ?%*ENV<AUTHOR_TESTING>;
 
@@ -9,8 +9,8 @@ if AUTHOR {
     # check for trailing spaces
     # check for tabs
     my @dirs = '.';
-    for Path::Iterator.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
-        my @lines = $file.IO.lines;
+    for Path::Finder.skip-vcs.ext(rx/ ^ ( 'p' <[lm]> 6? | t ) $ /).in(@dirs) -> $file {
+        my @lines = $file.lines;
         my @spaces = @lines.grep(rx/\s$/);
         is-deeply @spaces, [], "spaces at the end of $file";
 


### PR DESCRIPTION
I recently renamed `Path::Iterator` to `Path::Finder` in the mistaken belief that no one was using my entirely undocumented module. Sorry about the breakage.